### PR TITLE
openfoam2112: reorder dependencies

### DIFF
--- a/Casks/openfoam2112.rb
+++ b/Casks/openfoam2112.rb
@@ -24,11 +24,11 @@ cask "openfoam2112" do
   depends_on formula: "libomp"
   depends_on formula: "adios2"
   depends_on formula: "boost"
-  depends_on formula: "gerlero/openfoam/cgal@4"
   depends_on formula: "cmake"
   depends_on formula: "fftw"
   depends_on formula: "kahip"
   depends_on formula: "metis"
+  depends_on formula: "gerlero/openfoam/cgal@4"
   depends_on formula: "gerlero/openfoam/scotch-no-pthread"
 
   app "OpenFOAM-v2112.app"


### PR DESCRIPTION
Reorder dependencies to avoid `Error: Formula installation already attempted: cmake` when installing from scratch.