### PR TITLE
Update publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,7 @@ jobs:
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{ github.token }}
           HOMEBREW_GITHUB_PACKAGES_USER: ${{ github.actor }}
           PULL_REQUEST: ${{ github.event.pull_request.number }}
+          HOMEBREW_INSTALL_FROM_API: 1 # See https://github.com/Homebrew/brew/issues/15049
         run: brew pr-pull --debug --tap=$GITHUB_REPOSITORY $PULL_REQUEST
 
       - name: Push commits


### PR DESCRIPTION
 As suggested in https://github.com/Homebrew/brew/issues/15049, attempt to avoid the `pr-pull` failure seen when trying to merge #66 and #67.