### PR TITLE
cgal@4: deprecate

### DIFF
--- a/Formula/cgal@4.rb
+++ b/Formula/cgal@4.rb
@@ -20,6 +20,8 @@ class CgalAT4 < Formula
 
   keg_only :versioned_formula
 
+  deprecate! date: "2023-10-06", because: :versioned_formula
+
   depends_on "cmake" => [:build, :test]
   depends_on "boost"
   depends_on "eigen"


### PR DESCRIPTION
No longer used by any known projects (https://github.com/gerlero/openfoam-app/pull/141, https://github.com/BrushXue/OpenFOAM-AppleM1/pull/9)